### PR TITLE
Prevent extra link wrapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,17 @@ function markdownitLinkifyImages (md, config) {
     var imgClass = generateClass(config.imgClass)
     var otherAttributes = generateAttributes(md, token)
 
+    var imgElement = '<img src="' + url + '" alt="' + caption + '"' + imgClass + otherAttributes + '>'
+
+    if (idx > 0 && idx < tokens.length - 1 &&
+      tokens[idx - 1] && tokens[idx - 1].type === 'link_open' &&
+      tokens[idx + 1] && tokens[idx + 1].type === 'link_close') {
+      return imgElement
+    }
+
     return '' +
       '<a href="' + url + '"' + linkClass + target + '>' +
-      '<img src="' + url + '" alt="' + caption + '"' + imgClass + otherAttributes + '>' +
+      imgElement +
       '</a>'
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,14 @@ describe('markdown-it-linkify-images', function () {
     expect(result).to.eql('<p><a href="https://image.com/image.png" target="_self"><img src="https://image.com/image.png" alt="caption"></a></p>\n')
   })
 
+  it('does not add a link if the image is already wrapped by a link', function () {
+    this.md.use(linkifyImages)
+
+    var result = this.md.render('[![caption](https://image.com/image.png)](https://google.com)')
+
+    expect(result).to.eql('<p><a href="https://google.com"><img src="https://image.com/image.png" alt="caption"></a></p>\n')
+  })
+
   it('can add image titles in the linked image', function () {
     this.md.use(linkifyImages)
 


### PR DESCRIPTION
Fixes #45

- if img is wrapped by a link, return the constructed imgElement without link wrapping
- add test